### PR TITLE
Strip path from binary in first arg

### DIFF
--- a/evalcache.plugin.zsh
+++ b/evalcache.plugin.zsh
@@ -7,7 +7,8 @@
 export ZSH_EVALCACHE_DIR=${ZSH_EVALCACHE_DIR:-"$HOME/.zsh-evalcache"}
 
 function _evalcache () {
-  local cacheFile="$ZSH_EVALCACHE_DIR/init-$1.sh"
+  BINARY=$1
+  local cacheFile="$ZSH_EVALCACHE_DIR/init-${BINARY##*/}.sh"
 
   if [ "$ZSH_EVALCACHE_DISABLE" = "true" ]; then
     eval "$("$@")"

--- a/evalcache.plugin.zsh
+++ b/evalcache.plugin.zsh
@@ -7,8 +7,7 @@
 export ZSH_EVALCACHE_DIR=${ZSH_EVALCACHE_DIR:-"$HOME/.zsh-evalcache"}
 
 function _evalcache () {
-  BINARY=$1
-  local cacheFile="$ZSH_EVALCACHE_DIR/init-${BINARY##*/}.sh"
+  local cacheFile="$ZSH_EVALCACHE_DIR/init-${1##*/}.sh"
 
   if [ "$ZSH_EVALCACHE_DISABLE" = "true" ]; then
     eval "$("$@")"


### PR DESCRIPTION
This allows passing a binary with filepath, so long as there is no other cache with the same name.
Fixes #1 