### PR TITLE
Add hashed command content to cache file name

### DIFF
--- a/evalcache.plugin.zsh
+++ b/evalcache.plugin.zsh
@@ -7,7 +7,17 @@
 export ZSH_EVALCACHE_DIR=${ZSH_EVALCACHE_DIR:-"$HOME/.zsh-evalcache"}
 
 function _evalcache () {
-  local cacheFile="$ZSH_EVALCACHE_DIR/init-${1##*/}.sh"
+  local cmdHash="nohash"
+
+  # Use md5 on MacOS
+  if command -v md5 > /dev/null; then
+    cmdHash=$(echo -n "$*" | md5)
+  # Fallback to md5sum
+  elif command -v md5sum > /dev/null; then
+    cmdHash=$(echo -n "$*" | md5sum | cut -d' ' -f1)
+  fi
+
+  local cacheFile="$ZSH_EVALCACHE_DIR/init-${1##*/}-${cmdHash}.sh"
 
   if [ "$ZSH_EVALCACHE_DISABLE" = "true" ]; then
     eval "$("$@")"

--- a/evalcache.plugin.zsh
+++ b/evalcache.plugin.zsh
@@ -9,11 +9,9 @@ export ZSH_EVALCACHE_DIR=${ZSH_EVALCACHE_DIR:-"$HOME/.zsh-evalcache"}
 function _evalcache () {
   local cmdHash="nohash"
 
-  # Use md5 on MacOS
-  if command -v md5 > /dev/null; then
+  if builtin command -v md5 > /dev/null; then
     cmdHash=$(echo -n "$*" | md5)
-  # Fallback to md5sum
-  elif command -v md5sum > /dev/null; then
+  elif builtin command -v md5sum > /dev/null; then
     cmdHash=$(echo -n "$*" | md5sum | cut -d' ' -f1)
   fi
 


### PR DESCRIPTION
I need to cache these evals

```
_evalcache pyenv init -
_evalcache pyenv virtualenv-init -
_evalcache pyenv init --path
```

But currently, all these 3 commands generate the same cache file
```
init-pyenv.sh
```

So only 1 of them is cached.

To patch this, I added the md5 hash of the whole command (with args) to the cache file name.

