### PR TITLE
Fix error when type checking assignments

### DIFF
--- a/evalcache.plugin.zsh
+++ b/evalcache.plugin.zsh
@@ -17,18 +17,26 @@ function _evalcache () {
 
   local cacheFile="$ZSH_EVALCACHE_DIR/init-${1##*/}-${cmdHash}.sh"
 
+  local name
+  for i in {1..$#}; do
+    name=${@:$i:1}
+    if [[ $name != *'='* ]]; then
+      break
+    fi
+  done
+
   if [ "$ZSH_EVALCACHE_DISABLE" = "true" ]; then
     eval "$("$@")"
   elif [ -s "$cacheFile" ]; then
     source "$cacheFile"
   else
-    if type "$1" > /dev/null; then
-      (>&2 echo "$1 initialization not cached, caching output of: $*")
+    if type "$name" > /dev/null; then
+      (>&2 echo "$name initialization not cached, caching output of: $*")
       mkdir -p "$ZSH_EVALCACHE_DIR"
-      "$@" > "$cacheFile"
+      eval "$*" > "$cacheFile"
       source "$cacheFile"
     else
-      echo "evalcache ERROR: $1 is not installed or in PATH"
+      echo "evalcache ERROR: $name is not installed or in PATH"
     fi
   fi
 }


### PR DESCRIPTION
Some evals can have assignments first, this breaks evalcache because the return of `type thing=value` is false. 

For example, this is what [Pipenv](https://github.com/pypa/pipenv#shell-completion) suggests adding to get shell completion in Zsh:

```
eval "$(_PIPENV_COMPLETE=zsh_source pipenv)"
```

I think I managed to fix this edge case without breaking anything. It's probably not the best fix given my lack of experience with scripting and Zsh, but other ones I managed to write were uglier, so I settled.

Thought it might be nice to offer a PR, but I'll understand if you would rather reject it to be safe or any other reason.

In any case, I'm here to help if you want it.

PS: forgot to add, I know I could just export the variables before calling _evalcache, but I really wanted it to handle everything and keep things concise. 