### PR TITLE
Compile cached files.

### DIFF
--- a/evalcache.plugin.zsh
+++ b/evalcache.plugin.zsh
@@ -47,5 +47,5 @@ function _evalcache () {
 }
 
 function _evalcache_clear () {
-  rm -i "$ZSH_EVALCACHE_DIR"/init-*
+  rm -i "$ZSH_EVALCACHE_DIR"/init-*.{sh,zwc}
 }

--- a/evalcache.plugin.zsh
+++ b/evalcache.plugin.zsh
@@ -38,6 +38,7 @@ function _evalcache () {
       echo "evalcache: ${name} initialization not cached, caching output of: $*" >&2
       mkdir -p "$ZSH_EVALCACHE_DIR"
       eval ${(q)@} > "$cacheFile"
+      zcompile "$cacheFile"
       source "$cacheFile"
     else
       echo "evalcache: ERROR: ${name} is not installed or in PATH" >&2
@@ -46,5 +47,5 @@ function _evalcache () {
 }
 
 function _evalcache_clear () {
-  rm -i "$ZSH_EVALCACHE_DIR"/init-*.sh
+  rm -i "$ZSH_EVALCACHE_DIR"/init-*
 }


### PR DESCRIPTION
Introduces compiling of cache files for faster startup times. Also changed the remove glob? to match both the init-.sh and init-.zwc files.

Closes #12 @mroth @acevif
With only eval
```
archlinux% hyperfine --warmup 3 --min-runs 10 "zsh -l -i -c exit"
Benchmark 1: zsh -l -i -c exit
  Time (mean ± σ):      64.6 ms ±   1.8 ms    [User: 42.9 ms, System: 25.9 ms]
  Range (min … max):    62.7 ms …  69.1 ms    44 runs
```

With evallcache
```
archlinux% hyperfine --warmup 3 --min-runs 10 "zsh -l -i -c exit"
Benchmark 1: zsh -l -i -c exit
  Time (mean ± σ):      58.5 ms ±   1.1 ms    [User: 40.7 ms, System: 24.0 ms]
  Range (min … max):    57.6 ms …  63.1 ms    48 runs
```

With zcompile
```
hyperfine --warmup 3 --min-runs 10 "zsh -l -i -c exit"
Benchmark 1: zsh -l -i -c exit
  Time (mean ± σ):      55.4 ms ±   1.8 ms    [User: 38.8 ms, System: 22.7 ms]
  Range (min … max):    53.9 ms …  61.4 ms    50 runs
```

Difference between no evallcache and evallcache is around 5.1ms, and difference between the one with zcompile and the one without is 3.7ms

I used the following .zshrc
```zsh
ZINIT_HOME="${HOME}/.local/share/zinit/zinit.git"

if [ ! -d "$ZINIT_HOME" ]; then
   mkdir -p "$(dirname $ZINIT_HOME)"
   git clone https://github.com/zdharma-continuum/zinit.git "$ZINIT_HOME"
fi

source "${ZINIT_HOME}/zinit.zsh"

zinit wait lucid for \
 atinit"ZINIT[COMPINIT_OPTS]=-C; zicompinit; zicdreplay" \
    zdharma-continuum/fast-syntax-highlighting \
 blockf \
    zsh-users/zsh-completions \
 atload"!_zsh_autosuggest_start" \
    zsh-users/zsh-autosuggestions
zinit light Aloxaf/fzf-tab
zinit light mroth/evalcache

# Keybindings
bindkey -e
bindkey '^p' history-search-backward
bindkey '^n' history-search-forward
bindkey '^[w' kill-region

# History
HISTSIZE=5000
HISTFILE=~/.zsh_history
SAVEHIST=$HISTSIZE
HISTDUP=erase
setopt appendhistory
setopt sharehistory
setopt hist_ignore_space
setopt hist_ignore_all_dups
setopt hist_save_no_dups
setopt hist_ignore_dups
setopt hist_find_no_dups

# Completion styling
zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'
zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
zstyle ':completion:*' menu no
zstyle ':fzf-tab:complete:cd:*' fzf-preview 'ls --color $realpath'
zstyle ':fzf-tab:complete:__zoxide_z:*' fzf-preview 'ls --color $realpath'

# Aliases
alias ls='ls --color'

# Evals
_evalcache fzf --zsh
_evalcache zoxide init --cmd cd zsh
_evalcache mise activate zsh
```